### PR TITLE
Fix the spelling of address and use [] around the IPv6 address in the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ ansible-galaxy install sbaerlocher.snmp
 | snmp_encryption                | snmp_encryption                                                         | SNMP Encryption                                 |
 | snmp_contact                   |                                                                         | Optional: System Contact                        |
 | snmp_location                  |                                                                         | Optional: System Location                       |
-| snmp_agentadress_protocol.ipvX | udp / udp6                                                              | Optional: SNMP Protocol, X for ipv4 or ipv6     |
-| snmp_agentadress_adress.ipvX   | {{ ansible_default_ipv4.address }} / {{ ansible_default_ipv6.address }} | Optional: SNMP bind address, X for ipv4 or ipv6 |
-| snmp_agentadress_port.ipvX     | 161 / 161                                                               | Optional: SNMP port, X for ipv4 or ipv6         |
+| snmp_agentaddress_protocol.ipvX | udp / udp6                                                              | Optional: SNMP Protocol, X for ipv4 or ipv6     |
+| snmp_agentaddress_address.ipvX   | {{ ansible_default_ipv4.address }} / {{ ansible_default_ipv6.address }} | Optional: SNMP bind address, X for ipv4 or ipv6 |
+| snmp_agentaddress_port.ipvX     | 161 / 161                                                               | Optional: SNMP port, X for ipv4 or ipv6         |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,18 +5,18 @@ snmp_additional_packages: []
 snmp_encryption: snmp_encryption
 snmp_extension_scripts: '/usr/local/lib/snmpd'
 snmp_logging_options: ''
-snmp_access_adress: 0.0.0.0
+snmp_access_address: 0.0.0.0
 snmp_monitoring_server: 0.0.0.0
 snmp_password: snmp_password
 snmp_user: snmp
 
-snmp_agentadress_protocol:
+snmp_agentaddress_protocol:
   ipv4: udp
   ipv6: udp6
-snmp_agentadress_adress:
+snmp_agentaddress_address:
   ipv4: "{{ ansible_default_ipv4.address if ansible_default_ipv4.address is defined else '127.0.0.1' }}"
   ipv6: "{{ ansible_default_ipv6.address if ansible_default_ipv6.address is defined else '::1' }}"
-snmp_agentadress_port:
+snmp_agentaddress_port:
   ipv4: 161
   ipv6: 161
 

--- a/tasks/distribution/Microsoft Windows 10 Pro.yml
+++ b/tasks/distribution/Microsoft Windows 10 Pro.yml
@@ -18,7 +18,7 @@
     - path: PermittedManagers
       name: '1'
       type: string
-      data: '{{ snmp_access_adress | default() }}'
+      data: '{{ snmp_access_address | default() }}'
     - path: RFC1156Agent
       name: sysContact
       type: string
@@ -34,7 +34,7 @@
   notify:
     - restart win snmp
 
-- name: 'windows : set remote IP-Adresss'
+- name: 'windows : set remote IP-Addresss'
   set_fact:
     snmp_remoteip: "{{ lookup('dig', snmp_monitoring_server ) }}"
   when: not snmp_monitoring_server | ipaddr

--- a/tasks/distribution/Windows.yml
+++ b/tasks/distribution/Windows.yml
@@ -17,7 +17,7 @@
     - path: PermittedManagers
       name: '1'
       type: string
-      data: '{{ snmp_access_adress | default() }}'
+      data: '{{ snmp_access_address | default() }}'
     - path: RFC1156Agent
       name: sysContact
       type: string
@@ -33,7 +33,7 @@
   notify:
     - restart win snmp
 
-- name: 'windows : set remote IP-Adresss'
+- name: 'windows : set remote IP-Addresss'
   set_fact:
     snmp_remoteip: "{{ lookup('dig', snmp_monitoring_server ) }}"
   when: not snmp_monitoring_server | ipaddr

--- a/templates/snmp/snmpd.conf.j2
+++ b/templates/snmp/snmpd.conf.j2
@@ -4,10 +4,10 @@ createUser {{ snmp_user }} SHA {{ snmp_password }} AES {{ snmp_encryption }}
 
 rouser {{ snmp_user }} priv
 {% if ansible_default_ipv4.address is defined %}
-agentAddress  {{ snmp_agentadress_protocol.ipv4 }}:{{ snmp_agentadress_adress.ipv4 }}:{{ snmp_agentadress_port.ipv4 }}
+agentAddress  {{ snmp_agentaddress_protocol.ipv4 }}:{{ snmp_agentaddress_address.ipv4 }}:{{ snmp_agentaddress_port.ipv4 }}
 {% endif %}
 {% if ansible_default_ipv6.address is defined %}
-agentAddress {{ snmp_agentadress_protocol.ipv6 }}:{{ snmp_agentadress_adress.ipv6 }}:{{ snmp_agentadress_port.ipv6 }}
+agentAddress {{ snmp_agentaddress_protocol.ipv6 }}:[{{ snmp_agentaddress_address.ipv6 }}]:{{ snmp_agentaddress_port.ipv6 }}
 {% endif %}
 
 {% if snmp_location is defined %}


### PR DESCRIPTION
address is spelled wrong in some places, this PR will fix that.
Also the agentAddress in the snmpd.conf.j2 for the IPv6 address should be surrounded by []'s.
for example:
agentAddress udp6:[2001:db8:1::2:3:4]:161
instead of
agentAddress udp6:2001:db8:1::2:3:4:161
