### PR TITLE
[vars] fix: allow role to be used on debian 8

### DIFF
--- a/vars/Debian-8.yml
+++ b/vars/Debian-8.yml
@@ -1,0 +1,13 @@
+---
+# vars file for sbaerlocher.snmp
+
+snmp_packages:
+  - snmp
+  - snmpd
+
+snmp_config: '/etc/snmp/snmpd.conf'
+snmp_daemon_config: '/etc/default/snmpd'
+snmp_deamon_group: 'snmp'
+snmp_deamon_user: 'snmp'
+snmp_logging_options: '-Lsd'
+snmp_service_name: 'snmpd'


### PR DESCRIPTION
I had to build my own var file to make it work on a Debian 8.11 ; due to your nice inclusion task, it was easy to create a new one dedicated to my needs.

---

Their is also an issue where `snmp_logging_options` is defined as a default var but it can't be over-rided by user : https://github.com/sbaerlocher/ansible.snmp/blob/master/defaults/main.yml#L7

It should be defined as a var instead ; which will be automatically defined thanks to the kind of file I pushed. 